### PR TITLE
Command-line improvements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  branch = "master"
+  digest = "1:61eda50b1c7785c6d876b3d31053a677313d5a85309668f29f7cb6d7ac0f0ab6"
+  name = "github.com/christopherhein/go-version"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "fee8dd1f7c24da23508e26347694be0acce5631b"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -690,16 +698,18 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/christopherhein/go-version",
     "github.com/ghodss/yaml",
     "github.com/hashicorp/go-multierror",
     "github.com/operator-framework/operator-sdk/pkg/sdk",
     "github.com/operator-framework/operator-sdk/pkg/sdk/metrics",
+    "github.com/operator-framework/operator-sdk/pkg/util/k8sutil",
     "github.com/pkg/errors",
-    "github.com/sirupsen/logrus",
     "github.com/spf13/cobra",
     "istio.io/api/networking/v1alpha3",
     "istio.io/istio/pilot/pkg/config/kube/crd",
     "istio.io/istio/pilot/pkg/model",
+    "istio.io/istio/pilot/pkg/serviceregistry/kube",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 all: build
 
+build_date := $(shell date +%s)
+build_commit := $(shell git rev-parse --short HEAD)
+version ?= 0.2-dev
+
 deps: $(DEP)
 	@echo "Fetching dependencies..."
 	dep ensure -v
@@ -11,7 +15,11 @@ $(DEP):
 
 build: cw
 cw:
-	go build -o cw ./cmd/cw
+	go build -v -o cw -ldflags \
+	    "-X github.com/istio-ecosystem/coddiwomple/cmd.version=$(version) \
+	    -X github.com/istio-ecosystem/coddiwomple/cmd.date=$(build_date) \
+	    -X github.com/istio-ecosystem/coddiwomple/cmd.commit=$(build_commit)" \
+	    ./cmd/cw
 	@chmod +x cw
 
 clean:

--- a/cmd/gen.go
+++ b/cmd/gen.go
@@ -25,6 +25,23 @@ import (
 	"github.com/istio-ecosystem/coddiwomple/pkg/routing"
 )
 
+func genCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gen",
+		Short: "Generate config files",
+		Long:  `Generate various Istio resource descriptions, and Coddiwomple config files`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return errors.New("cannot use gen directly, use a subcommand")
+		},
+	}
+
+	cmd.AddCommand(
+		configGenCmd(),
+	)
+
+	return cmd
+}
+
 func configGenCmd() *cobra.Command {
 
 	var (
@@ -36,9 +53,9 @@ func configGenCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:     "gen",
+		Use:     "config",
 		Short:   "Generates Istio config for each cluster for the target service.",
-		Example: "cw gen ",
+		Example: "cw gen config",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ func Root() *cobra.Command {
 	rootCmd.AddCommand(
 		uiCmd(),
 		genCmd(),
+		versionCmd(),
 	)
 
 	return rootCmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ import (
 func Root() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "cw",
-		Short: "Coddiwomple creates mantifests",
+		Short: "Coddiwomple creates manifests for cross-cluster routing",
 		Long:  `Coddiwomple, a multi-cloud cross-cluster configuration generator for Istio`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.New("cannot use cw directly, use a subcommand")
@@ -32,7 +32,7 @@ func Root() *cobra.Command {
 
 	rootCmd.AddCommand(
 		uiCmd(),
-		configGenCmd(),
+		genCmd(),
 	)
 
 	return rootCmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+
+	goVersion "github.com/christopherhein/go-version"
+	"github.com/spf13/cobra"
+)
+
+var (
+	shortened = false
+	version   string
+	commit    string
+	date      string
+)
+
+func versionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Version will output the current build information",
+		Long:  ``,
+		Run: func(_ *cobra.Command, _ []string) {
+			var response string
+			versionOutput := goVersion.New(version, commit, date)
+
+			if shortened {
+				response = versionOutput.ToShortened()
+			} else {
+				response = versionOutput.ToJSON()
+			}
+			fmt.Printf("%+v", response)
+			return
+		},
+	}
+
+	cmd.Flags().BoolVarP(&shortened, "short", "s", false, "Use shortened output for version information.")
+
+	return cmd
+}


### PR DESCRIPTION
Bad branch name, but in this PR:
* Move `cw gen` to `cw gen configs` to make room for `cw gen [clusters,services]`
* Add `cw version` (what do people thing of the library choices?)